### PR TITLE
Fix exception: NoMethodError: "undefined method `status' for #<Farada…

### DIFF
--- a/lib/active_campaign/errors.rb
+++ b/lib/active_campaign/errors.rb
@@ -27,6 +27,14 @@ module ActiveCampaign
     def message
       if response.nil?
         super
+      elsif response.is_a?(Exception)
+        <<~MESSAGE
+          ERROR: #{response.class.name}: #{response}
+          URL: #{env.url}
+          REQUEST HEADERS: #{env.request_headers}
+          RESPONSE_HEADERS: #{env.response_headers}
+          REQUEST_BODY: #{env.request_body}\n\n"
+        MESSAGE
       else
         <<~MESSAGE
           STATUS: #{response.status}


### PR DESCRIPTION
…y::TimeoutError:...>"

Somehow Faraday::TimeoutError object is passed as `response` parameter. In this case it doesn't have status or body, but the request url/headers still matter.
Probably the bug is in a different place that passes the invalid `response` parameter, but even if that bug will be found and fixed, this change can stay as a failsafe.